### PR TITLE
fix windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,11 @@ set(SOURCES TaskScheduler.cpp)
 add_library(${SCHEDULER} ${SOURCES} ${HEADERS})
 target_include_directories(${SCHEDULER}
                            PUBLIC ./)
-target_link_libraries(${SCHEDULER}
-                      PUBLIC pthread)
+
+if(UNIX)
+    target_link_libraries(${SCHEDULER}
+                          PUBLIC pthread)
+endif(UNIX)
 
 add_executable(${SCHEDULER}_exe main.cpp ${SOURCES} ${HEADERS})
 target_include_directories(${SCHEDULER}_exe

--- a/TaskScheduler.cpp
+++ b/TaskScheduler.cpp
@@ -34,18 +34,6 @@ void Scheduler::ScheduleRepeatable(std::chrono::system_clock::duration interval,
     this->ScheduleEveryIntern(interval, threadFunc, repeats);
 }
 
-void Scheduler::ScheduleAt(const std::string &time, std::function<void()> func)
-{
-    if (time.find("*") == std::string::npos && time.find("/") == std::string::npos)
-    {
-        std::tm tm = {};
-        strptime(time.c_str(), "%s %M %H %d %m %Y", &tm);
-        auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-        if (tp > std::chrono::system_clock::now())
-            ScheduleTask(tp, std::move(func));
-    }
-}
-
 void Scheduler::ScheduleTask(const std::chrono::system_clock::time_point &time, std::function<void()> &&func)
 {
     tasks.push(function_timer(std::move(func), time));

--- a/TaskScheduler.h
+++ b/TaskScheduler.h
@@ -2,6 +2,7 @@
 #include <chrono>
 #include <thread>
 #include <memory>
+#include <ctime>
 #include <functional>
 
 namespace
@@ -50,17 +51,15 @@ public:
     ~Scheduler();
     // Schedule single call of @func when the @time comes
     void ScheduleAt(const std::chrono::system_clock::time_point &time, std::function<void()> &&func);
-    // Same with @time in format "%s %M %H %d %m %Y" "sec min hour date month year"
-    void ScheduleAt(const std::string &time, std::function<void()> func);
-    // Schedule endless calls of @func with given @inverval
+    // Schedule endless calls of @func with given @interval
     void ScheduleEndless(std::chrono::system_clock::duration interval, std::function<void()> func);
-    // Schedule @repeats amount of calls of @func with given @inverval
+    // Schedule @repeats amount of calls of @func with given @interval
     void ScheduleRepeatable(std::chrono::system_clock::duration interval, std::function<void()> func, int repeats);
 
 private:
     // Insert task into tasks pool
     void ScheduleTask(const std::chrono::system_clock::time_point &time, std::function<void()> &&func);
-    /// Shedule @func call after @interval time if @repeats not equals to 0
+    /// Schedule @func call after @interval time if @repeats not equals to 0
     /// Use repeats < 0 for endless scheduling
     void ScheduleEveryIntern(std::chrono::system_clock::duration interval, std::function<void()> func, int repeats);
     void ThreadLoop();

--- a/main.cpp
+++ b/main.cpp
@@ -20,6 +20,6 @@ int main(int argc, char const *argv[])
     sch.ScheduleRepeatable(std::chrono::seconds(1), [&]{
         std::cout << "Limited calls" << std::endl;
     }, 3);
-    while (true);
+    while (true); // Keep running
     return 0;
 }


### PR DESCRIPTION
Remove unused badly portable ScheduleAt with a formatted-string timestamp.
Set pthread linking for Unix-systems only.
Add ctime include.
Fix typos.